### PR TITLE
remove edit config minSdk 19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## [2.4.6](https://github.com/spoonconsulting/cordova-plugin-genius-scan/pull/2/files) (2020-09-16)
+
+
+### Bug Fixes
+
+* **minSdk:** remove edit-config for minSdk from plugin.xml, this can be configured in app itself. ([#2])

--- a/package.json
+++ b/package.json
@@ -75,5 +75,5 @@
     "the grizzly labs"
   ],
   "name": "@thegrizzlylabs/cordova-plugin-genius-scan",
-  "version": "2.4.2"
+  "version": "2.4.6"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -10,9 +10,6 @@
         <param name="android-package" value="com.thegrizzlylabs.geniusscan.cordova.GeniusScan" />
       </feature>
     </config-file>
-    <edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="merge">
-      <uses-sdk android:minSdkVersion="19" />
-    </edit-config>
     <config-file parent="/*" target="AndroidManifest.xml">
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
       <uses-permission android:name="android.permission.CAMERA" />


### PR DESCRIPTION
### Why ###
**Error**: _Unable to graft xml at selector "/manifest/uses-sdk" from "platforms\android\app\src\main\AndroidManifest.xml"_

due to 

``` 
<edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="merge">	
    <uses-sdk android:minSdkVersion="19" />	
 </edit-config>
```

### FIX ###
By removing
``` 
<edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="merge">	
    <uses-sdk android:minSdkVersion="19" />	
 </edit-config>
``` 
from  plugin.xml
